### PR TITLE
Home Assistant MQTT fan percentage fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ fan:
   command_topic: "home/hamptonbay/1000/on/set"
   percentage_state_topic: "home/hamptonbay/1000/speed/state"
   percentage_value_template: >-
-    {% if value == 'low' -%}
+    {% if value == 'off' -%}
+    0
+    {% elif value == 'low' -%}
     1
     {%- elif value == 'medium' -%}
     2
@@ -59,7 +61,9 @@ fan:
     {%- endif %}
   percentage_command_topic: "home/hamptonbay/1000/speed/set"
   percentage_command_template: >-
-    {% if value | int(default=0) <= 1 -%}
+    {% if value | int(default=0) == 0 -%}
+    off
+    {%- elif value | int(default=0) == 1 -%}
     low
     {%- elif value | int(default=0) == 2 -%}
     medium

--- a/hampton_bay_fan_mqtt/hampton_bay_fan_mqtt.ino
+++ b/hampton_bay_fan_mqtt/hampton_bay_fan_mqtt.ino
@@ -44,6 +44,7 @@
 #define RF_REPEATS  8
 
 // Define fan states
+#define FAN_OFF 0
 #define FAN_HI  1
 #define FAN_MED 2
 #define FAN_LOW 3
@@ -181,6 +182,15 @@ void callback(char* topic, byte* payload, unsigned int length) {
       }
       else if(strcmp(payloadChar, "high") == 0) {
         fans[idint].fanSpeed = FAN_HI;
+      }
+
+      if(strcmp(payloadChar, "off") == 0) {
+        // 'off' state is not recorded, just turn the fan off
+        fans[idint].fanState = false;
+      }
+      else {
+        // Turn on fan when speed is updated
+        fans[idint].fanState = true;
       }
     }
     else if(strcmp(attr, "light") == 0) {


### PR DESCRIPTION
Adds handling of `0` percent speed states sent by Home Assistant instead of `OFF` states when using fan speed percentages.

Should fix #7 