### PR TITLE
ESP32 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Hampton Bay Fan MQTT
 
 ## Overview
-ESP8266 project enabling MQTT control for a Hampton Bay fan with a wireless receiver. Wireless communication is performed with a CC1101 wireless transceiver operating at 303 MHz.
+ESP8266/ESP32 project enabling MQTT control for a Hampton Bay fan with a wireless receiver. Wireless communication is performed with a CC1101 wireless transceiver operating at 303 MHz.
 
 This will also monitor for Hampton Bay RF signals so the state will stay in sync even if the original remote is used to control the fan.
 
-Fan control is not limited to a single dip switch setting, so up to 16 fans can be controlled with one ESP8266.
+Fan control is not limited to a single dip switch setting, so up to 16 fans can be controlled with one ESP8266/ESP32.
 
 ## Dependencies
 This project uses the following libraries that are available through the Arduino IDE
@@ -14,7 +14,7 @@ This project uses the following libraries that are available through the Arduino
 * [PubSubClient](https://pubsubclient.knolleary.net/) by Nick O'Leary
 
 ## Hardware
-* ESP8266 development board (Tested with a NodeMCU v2 and a D1 Mini)
+* ESP8266/ESP32 development board (Tested with a NodeMCU v2 and a D1 Mini)
 * CC1101 wireless transceiver
   * Wiring info can be found in the [SmartRC-CC1101-Driver-Lib readme](https://github.com/LSatan/SmartRC-CC1101-Driver-Lib#wiring)
 

--- a/hampton_bay_fan_mqtt/hampton_bay_fan_mqtt.ino
+++ b/hampton_bay_fan_mqtt/hampton_bay_fan_mqtt.ino
@@ -1,6 +1,10 @@
 #include <ELECHOUSE_CC1101_SRC_DRV.h>
 #include <RCSwitch.h>
-#include <ESP8266WiFi.h>
+#ifdef ESP32
+  #include <WiFi.h>
+#elif ESP8266
+  #include <ESP8266WiFi.h>
+#endif
 #include <PubSubClient.h>
 
 // Configure wifi settings
@@ -27,6 +31,10 @@
 #ifdef ESP32 // for esp32! Receiver on GPIO pin 4. Transmit on GPIO pin 2.
   #define RX_PIN 4 
   #define TX_PIN 2
+  #define SCK_PIN 18
+  #define SS_PIN 5
+  #define MISO_PIN 19
+  #define MOSI_PIN 23
 #elif ESP8266  // for esp8266! Receiver on pin 4 = D2. Transmit on pin 5 = D1.
   #define RX_PIN 4
   #define TX_PIN 5
@@ -259,10 +267,21 @@ void setup() {
     fans[i].fanSpeed = FAN_OFF;
   }
 
+#ifdef ESP32 // Override Spi pin assignments for ESP32 only
+  ELECHOUSE_cc1101.setSpiPin(SCK_PIN, MISO_PIN, MOSI_PIN, SS_PIN);
+  ELECHOUSE_cc1101.setGDO(TX_PIN, RX_PIN);
+#endif
+
   ELECHOUSE_cc1101.Init();
   ELECHOUSE_cc1101.setMHZ(FREQUENCY);
   ELECHOUSE_cc1101.SetRx();
   mySwitch.enableReceive(RX_PIN);
+
+  if (ELECHOUSE_cc1101.getCC1101()){       // Check the CC1101 Spi connection.
+  Serial.println("CC1101 Connection OK");
+  }else{
+  Serial.println("CC1101 Connection Error");
+  }
 
   setup_wifi();
   client.setServer(MQTT_HOST, MQTT_PORT);


### PR DESCRIPTION
Hello! A few changes are needed to build and run this project on ESP32. 

- WiFi library
  - Fails to build without it

- Init cc1101 with ESP32 pinout declared 
  - The default init causes a boot loop, as a restricted pin is pulled.
  - Several issues on the upstream repo and Arduino forums reference the ESP32 pinout, and passing the exact pins to the library before init ([example](https://github.com/LSatan/SmartRC-CC1101-Driver-Lib/issues/138)). 
    - Simply declaring and setting the pins allowed the board and radio to initialize, wiring is the same as the reference.
    - Added the standard cc1101 init check (it correctly reports if the wiring is wrong)

----

The data pins (both SPI and interrupt) can be set to any open GPIO on ESP32. For instance, I use the following pinout on a D1 mini:
```
  #define RX_PIN 36
  #define TX_PIN 5
  #define SCK_PIN 19
  #define SS_PIN 23
  #define MISO_PIN 26
  #define MOSI_PIN 18
```