### PR TITLE
Brightness/Dimming + Checksum codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ By default, the state/command topics will be
 * Light on/off (payload `ON` or `OFF`)
   * `home/hamptonbay/<fan_id>/light/state`
   * `home/hamptonbay/<fan_id>/light/set`
+* Light brightness (payload `int`)
+  * `home/hamptonbay/<fan_id>/brightness/state`
+  * `home/hamptonbay/<fan_id>/brightness/set`
 
 `fan_id` is a 4-digit binary number determined by the dip switch settings on the transmitter/receiver where up = 1 and down = 0. For example, the dip setting:
 
@@ -77,4 +80,9 @@ light:
   name: "Bedroom Fan Light"
   state_topic: "home/hamptonbay/1000/light/state"
   command_topic: "home/hamptonbay/1000/light/set"
+  brightness_command_topic: "home/hamptonbay/1000/brightness/set"
+  brightness_state_topic: "home/hamptonbay/1000/brightness/state"
+  brightness_command_template: {{ value | int }}
+  brightness_value_template: {{ value | int }}
+  brightness_scale: 255
 ```

--- a/hampton_bay_fan_mqtt/hampton_bay_fan_mqtt.ino
+++ b/hampton_bay_fan_mqtt/hampton_bay_fan_mqtt.ino
@@ -22,6 +22,8 @@
 #define SUBSCRIBE_TOPIC_SPEED_STATE BASE_TOPIC "/+/speed/state"
 #define SUBSCRIBE_TOPIC_LIGHT_SET BASE_TOPIC "/+/light/set"
 #define SUBSCRIBE_TOPIC_LIGHT_STATE BASE_TOPIC "/+/light/state"
+#define SUBSCRIBE_TOPIC_BRIGHTNESS_SET BASE_TOPIC "/+/brightness/set"
+#define SUBSCRIBE_TOPIC_BRIGHTNESS_STATE BASE_TOPIC "/+/brightness/state"
 
 // Set receive and transmit pin numbers (GDO0 and GDO2)
 #ifdef ESP32 // for esp32! Receiver on GPIO pin 4. Transmit on GPIO pin 2.
@@ -68,6 +70,7 @@ struct fan
   bool lightState;
   bool fanState;
   uint8_t fanSpeed;
+  uint8_t lightBrightness;
 };
 fan fans[16];
 
@@ -88,6 +91,37 @@ const char *idStrings[16] = {
     [12] = "1100", [13] = "1101", [14] = "1110", [15] = "1111",
 };
 char idchars[] = "01";
+
+int calculateBrightness(int value, bool mode) {
+  // Brightness values are based on an inverted integer scale,
+  // where 50 = 1% and 1 = 100%. 0 is off. MQTT range is 1-255.
+  if (value == 0) {
+    return 0;
+  }
+  if (!mode) {
+    int invertedIndex = map(value, 1, 255, 50, 1); // Encode for transmit
+    // Return as 6-bit binary (00111111)
+    // Minimum safe brightness is 41 = 20%
+    return (invertedIndex > 41 ? 41 : invertedIndex) & 0x3F;
+  }
+  else {
+    return map(value, 50, 1, 1, 255); // Decode after receive
+  }
+}
+
+int calculateChecksum(int number) {
+  // Checksum required on some models
+  // It is calculated by adding each of the 4-bit chunks that precede it
+  // (16-bits in all) and putting the remainder in these bits
+  int sum = 0;
+
+  while (number > 0) {
+    sum += number & 0xF;
+    number >>= 4;
+  }
+
+  return sum % 16;
+}
 
 void setup_wifi() {
 
@@ -119,16 +153,19 @@ void transmitState(int fanId) {
   mySwitch.setRepeatTransmit(RF_REPEATS); // transmission repetitions.
   mySwitch.setProtocol(RF_PROTOCOL);        // send Received Protocol
 
-  // Determine fan component of RF code
+  // Determine light and fan components of RF code
+  int lightRf = fans[fanId].lightState ? calculateBrightness(fans[fanId].lightBrightness, 0) : 0;
   int fanRf = fans[fanId].fanState ? fans[fanId].fanSpeed : 0;
   // Build out RF code
   //   Code follows the 21 bit pattern
-  //   000xxxx000000yzz00000
+  //   000xxxxaaaaaaazzbbbbb
   //   Where x is the inversed/reversed dip setting, 
-  //     y is light state, z is fan speed
-  int rfCode = dipToRfIds[fanId] << 14 | fans[fanId].lightState << 7 | fanRf << 5;
-  
-  mySwitch.send(rfCode, 21);      // send 21 bit code
+  //         a is brightness, z is fan speed
+  //         b is a checksum on some models (00000 otherwise)
+  int rfCode = dipToRfIds[fanId] << 9 | lightRf << 2 | fanRf;
+  int rfCodeSum = rfCode << 5 | calculateChecksum(rfCode);
+
+  mySwitch.send(rfCodeSum, 21);      // send 21 bit code
   ELECHOUSE_cc1101.SetRx();      // set Receive on
   mySwitch.disableTransmit();   // set Transmit off
   mySwitch.enableReceive(RX_PIN);   // Receiver on
@@ -203,6 +240,13 @@ void callback(char* topic, byte* payload, unsigned int length) {
         fans[idint].lightState = false;
       }
     }
+    else if(strcmp(attr, "brightness") == 0) {
+      int payloadInt = atoi(payloadChar);
+      fans[idint].lightBrightness = payloadInt;
+      if(strcmp(payloadChar, "0") == 0) {
+        fans[idint].lightState = false;
+      }
+    }
     if(strcmp(action, "set") == 0) {
       transmitState(idint);
     }
@@ -221,6 +265,8 @@ void postStateUpdate(int id) {
   client.publish(outTopic, fanStateTable[fans[id].fanSpeed], true);
   sprintf(outTopic, "%s/%s/light/state", BASE_TOPIC, idStrings[id]);
   client.publish(outTopic, fans[id].lightState ? "ON":"OFF", true);
+  sprintf(outTopic, "%s/%s/brightness/state", BASE_TOPIC, idStrings[id]);
+  client.publish(outTopic, String(fans[id].lightBrightness).c_str(), true);
 }
 
 void reconnect() {
@@ -239,6 +285,8 @@ void reconnect() {
       client.subscribe(SUBSCRIBE_TOPIC_SPEED_STATE);
       client.subscribe(SUBSCRIBE_TOPIC_LIGHT_SET);
       client.subscribe(SUBSCRIBE_TOPIC_LIGHT_STATE);
+      client.subscribe(SUBSCRIBE_TOPIC_BRIGHTNESS_SET);
+      client.subscribe(SUBSCRIBE_TOPIC_BRIGHTNESS_STATE);
     } else {
       Serial.print("failed, rc=");
       Serial.print(client.state());
@@ -255,6 +303,7 @@ void setup() {
   // initialize fan struct
   for(int i=0; i<16; i++) {
     fans[i].lightState = false;
+    fans[i].lightBrightness = 0;
     fans[i].fanState = false;
     fans[i].fanSpeed = FAN_OFF;
   }
@@ -289,18 +338,18 @@ void loop() {
     Serial.println(bits);
 
     if( prot == 6 && bits == 21 ) {
-      int id = value >> 14;
+      // Isolate out all payload segments
+      int id     = (value >> 14) & 0b1111;
+      int states = (value >> 5)  & 0b111111111;
+      int light  = (states >> 2) & 0b1111111;
+      int fan    = states        & 0b11;
+      int sum    = value         & 0b11111;
       // Got a correct id in the correct protocol
       if(id < 16) {
         // Convert to dip id
         int dipId = dipToRfIds[id];
         Serial.print("Received command from ID - ");
         Serial.println(dipId);
-        // Blank out id in message to get light state
-        int states = value & 0b11111111;
-        bool light = states >> 7;
-        // Blank out light state to get fan state
-        int fan = (states & 0b01111111) >> 5;
         if(fan == 0) {
           fans[dipId].fanState = false;
         }
@@ -308,7 +357,14 @@ void loop() {
           fans[dipId].fanState = true;
           fans[dipId].fanSpeed = fan;
         }
-        fans[dipId].lightState = light;
+        if(light == 0) {
+          fans[dipId].lightState = false;
+          fans[dipId].lightBrightness = 0;
+        }
+        else {
+          fans[dipId].lightState = true;
+          fans[dipId].lightBrightness = calculateBrightness(light, 1);
+        }
         postStateUpdate(dipId);
       }
     }


### PR DESCRIPTION
Building off the great work and notes in https://github.com/owenb321/hampton-bay-fan-mqtt/issues/5#issue-2195555184, I've gotten dimming/brightness control working on the receivers for my ([CHQ7096T](https://fcc.report/FCC-ID/CHQ7096T)) Hampton Bay remotes (4x different fixtures!). 

I've integrated the original checksum patch written by @Concours99, and here are my notes and the code changes for brightness TX and RX. Thanks everyone for all the hard work on this sketch and documenting the codes, looking forward to feedback!

MQTT
----

Additional MQTT config for brightness:

```yaml
light:
- platform: mqtt
  name: "Bedroom Fan Light"
...
  brightness_command_topic: "home/hamptonbay/1000/brightness/set"
  brightness_state_topic: "home/hamptonbay/1000/brightness/state"
  brightness_command_template: {{ value | int }}
  brightness_value_template: {{ value | int }}
  brightness_scale: 255
```

Notes
----

I have similar remotes to the author of the checksum fix, two OEM ones transmitting on **303.85mhz**, then an unbranded clone and an [Anderic replacement](https://www.amazon.com/Anderic-CHQ7096T-Fan-Timer-Key/dp/B06XG2RNJT) on **302.739mhz**. The two older ones are 2002 manufactured, board `7096T V5` (OEM Hampton Bay logo), where the newer 302mhz are both 2008 `7096T V7`. The receiver in one of the newer pairs is `MR181A-3`. All remotes are all visually identical with the same optional functions (dimming/temp/fan timer).

Despite the frequency difference, all of the receivers play nice with all of the remotes, and they all follow the same bit pattern: the checksum is present in codes from both sets of remotes. The two older remotes are designated `Protocol 6` while the newer ones are [protocol 11](https://github.com/sui77/rc-switch/blob/master/RCSwitch.cpp#L92). Including this protocol allows all four remotes to be received and decoded the same. 

```diff
- if( prot == 6 && bits == 21 ) {
+ if(( prot == 6 || prot == 11 ) && bits == 21 ) {
```

----

When holding the light button on these remotes for more than two seconds, the brightness percentage scales up and down from 100%-20% and back again for the duration of the press. The remote rapidly sends 3 payloads for each percentage change, likely to ensure the last payload received is the correct one. 

I scanned their codes and broke it down based on this schema:

> What I have determined for my remote is similar:
000xxxxaaaaaaazzbbbbb
> aaaaaaa is a value that indicates the percentage the light is on. I haven't decoded all the possible values for this, but 0000001 and 0000000 are on and off, respectively. 

```
ID      LIGHT   FAN  SUM     BRIGHTNESS

0001111 0000000 00   01111   0%
0001110 0000001 01   00010   100%
0001110 0001011 00   01011   80%
```

The value is a 6-bit binary, representing an inverted decimal scale of 1-50:

```
BIN     INT   BRIGHTNESS
 
000000  0     0% (light off)
000001  1     100%
000110  6     90%
001011  11    80%
011010  26    50%
101001  41    20% (lowest remote goes)
110010  50    1%
```

The receivers can target any brightness level without in-between, the linear seek from the OEM remote simulates a smooth dimming effect on older fixtures by rapidly cycling up and down the index in steps of 2%. The remotes bottom out at 20%, manually setting less technically works, but provides insufficient power (LED dimmer bulbs flicker). 

----

With that figured out, the trick was mapping the MQTT brightness scale (0-255) to the fan's reversed integer index (50-0), then in reverse to decode from received remote commands. `map()` works great, albeit with rounding inaccuracy when converting in the upper direction: 

```
TX
map(value, 1, 255, 50, 1);
50% brightness requested -> 128 MQTT -> 26(011010) RF (correct)

RX
map(value, 50, 1, 1, 255);
26(010010) RF -> 125 MQTT -> 49% brightness (incorrect)
```

Setting MQTT's `brightness_scale: 100` and `map(value, 1, 100, 50, 1);` to works to cleanly convert both directions, but 100 is nonstandard for brightness values, 255 is the default scale in most platforms. It may be best to follow the standard and fix the conversion, either in the sketch or the MQTT template. 

I'll update if I fix this small inaccuracy, honestly nobody in the house is going to look at an original remote past this point though :slightly_smiling_face: 

----

Long-winded for ceiling fan code, but this was very fun to learn and get working! 

It would be cool to test to see if `rfCodeSum` safely works on models that otherwise use `00000` in place of the brightness bits and/or checksum. If they ignore the set bits and accept the commands, then this enhancement could apply to more models than 7096T. 